### PR TITLE
Update Calendar and FAQs for 2024

### DIFF
--- a/src/components/About/index.jsx
+++ b/src/components/About/index.jsx
@@ -12,8 +12,7 @@ const About = () => (
           ECE Day is a celebration of the students and faculty members of the ECE Department at
           UCSD. We’ll be having a surprise faculty speaker, tabling events, workshops, and socials
           for you to attend. Students that attend events will earn raffle tickets, which can go
-          towards winning our prizes, which include speakers, keyboards, and a Nintendo Switch! We
-          look forward to seeing you there!
+          towards winning our prizes! We look forward to seeing you there!
         </p>
       </div>
     </div>

--- a/src/components/FAQ/index.jsx
+++ b/src/components/FAQ/index.jsx
@@ -4,7 +4,7 @@ import style from './style.module.scss';
 const questions = [
   {
     q: 'What is ECE Day?',
-    a: 'ECE Day is a celebration of the students and faculty members of the ECE Department at UCSD. We’ll be having a surprise faculty speaker, tabling events, workshops, and socials for you to attend. Students that attend events will earn raffle tickets, which can go towards winning our prizes, which include speakers, keyboards, and a Nintendo Switch! We look forward to seeing you there!',
+    a: 'ECE Day is a celebration of the students and faculty members of the ECE Department at UCSD. We’ll be having a surprise faculty speaker, tabling events, workshops, and socials for you to attend. Students that attend events will earn raffle tickets, which can go towards winning our prizes! We look forward to seeing you there!',
   },
   {
     q: 'Who can attend?',
@@ -16,7 +16,7 @@ const questions = [
   },
   {
     q: 'When is it?',
-    a: 'ECE Day 2023 will be on April 14, 2023. We will be hosting a variety of events on Warren Mall and in Jacob’s Hall. Be sure to check our calendar to see which event is being held where!',
+    a: 'ECE Day 2024 will be on April 12, 2024. We will be hosting a variety of events on Warren Mall and in Jacob’s Hall. Be sure to check our calendar to see which event is being held where!',
   },
   {
     q: 'Does it cost money?',

--- a/src/components/FAQ/index.jsx
+++ b/src/components/FAQ/index.jsx
@@ -48,7 +48,7 @@ export default function FAQ() {
           />
           <FAQItem
             title="When is ECE Day?"
-            description="ECE Day 2023 will be on April 14, 2023. Be sure to check our calendar to stay updated!"
+            description="ECE Day 2024 will be on April 12, 2024. Be sure to check our calendar to stay updated!"
           />
           <FAQItem
             title="How do I sign up?"

--- a/src/components/Schedule/index.jsx
+++ b/src/components/Schedule/index.jsx
@@ -2,8 +2,8 @@ import * as moment from 'moment';
 import { useEffect, useState } from 'react';
 import style from './style.module.scss';
 
-const CAL_API = 'AIzaSyBbeJA33TZOj0WfZtv9DNC9Yxe6MrjWbLQ';
-const CAL_ID = 'eceday%40eng.ucsd.edu';
+const CAL_API = 'AIzaSyCaTQUMVuHM1jzm1QzsU3QagNNpwkPZgP4';
+const CAL_ID = 'eceday@ucsd.edu';
 const BASEPARAMS = `orderBy=startTime&singleEvents=true&timeMin=${new Date().toISOString()}`;
 const BASEURL = `https://www.googleapis.com/calendar/v3/calendars/${CAL_ID}/events?${BASEPARAMS}`;
 const finalURL = `${BASEURL}${`&maxResults=${30}`}&key=${CAL_API}`;


### PR DESCRIPTION
* FAQs weren't updated -- updated with new dates
* eng.ucsd.edu -> ucsd.edu domain change for calendar, and updating api keys